### PR TITLE
Fixed typo in the PropertyListingScheme for longitude

### DIFF
--- a/tests/tests_zoopla.py
+++ b/tests/tests_zoopla.py
@@ -100,3 +100,5 @@ def test_richlist(client):
     assert 'highest' in rl
     for l in rl.highest:
         assert 'name' in l
+
+		

--- a/tests/tests_zoopla.py
+++ b/tests/tests_zoopla.py
@@ -100,5 +100,3 @@ def test_richlist(client):
     assert 'highest' in rl
     for l in rl.highest:
         assert 'name' in l
-
-		

--- a/zoopla/schemas.py
+++ b/zoopla/schemas.py
@@ -120,7 +120,7 @@ class PropertyListingSchema(BaseSchema):
     image_url = fields.String()
 
     latitude = fields.Float()
-    longitudine = fields.Float()
+    longitude = fields.Float()
 
     num_bathrooms = fields.Integer()
     num_bedrooms = fields.Integer()


### PR DESCRIPTION
Fixed typo in the PropertyListingScheme for longitude. Have tested locally and can now get full long and lat co-ordinates from a property_listings call. 