### PR TITLE
Make `setup.py` dependency versions less strictly pinned

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,9 +55,9 @@ setup(name='zoopla',
       license='MIT',
       packages=['zoopla'],
       install_requires=[
-          'marshmallow==2.13.6',
-          'requests==2.11.1',
-          'enum34==1.1.6'
+          'marshmallow>=2.13.6,<3',
+          'requests>=2.11.1,<3',
+          'enum34>=1.1.6,<2'
       ],
       classifiers=[
           'Intended Audience :: Developers',


### PR DESCRIPTION
If a project using the `zoopla` library also depends on one of `zoopla`'s dependencies (`marshmallow`, `requests`, `enum34`), they see a warning message if there's a slight version mismatch (AKA dependency hell...)

```
zoopla 0.6.3 has requirement requests==2.11.1, but you'll have requests 2.18.4 which is incompatible.
```

Make `setup.py` more flexible, specifying a minimum rather than an exact version (and it constraining it to stay within the next major version of the dependency)

[install_requires vs requirements files](https://packaging.python.org/discussions/install-requires-vs-requirements/#install-requires-vs-requirements-files] has some good guidance on this and other suggestions.

> It is not considered best practice to use install_requires to pin dependencies to specific versions, or to specify sub-dependencies (i.e. dependencies of your dependencies). This is overly-restrictive, and prevents the user from gaining the benefit of dependency upgrades.