### PR TITLE
Add missing `price_modifier` to property listings

### DIFF
--- a/zoopla/schemas.py
+++ b/zoopla/schemas.py
@@ -100,6 +100,7 @@ class PropertyListingSchema(BaseSchema):
     listing_status = fields.String()
 
     price = fields.Float()
+    price_modifier = fields.String()
 
     agent_address = fields.String()
     agent_logo = fields.URL()


### PR DESCRIPTION
From the [Zoopla API docs](https://developer.zoopla.co.uk/docs/read/Property_listings)
> Restrictions related to the price of the listing, specifically: "offers_over", "poa", "fixed_price", "from", "offers_in_region_of", "part_buy_part_rent", "price_on_request", "shared_equity", "shared_ownership", "guide_price", "sale_by_tender".